### PR TITLE
Add basic Kubernetes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,60 +8,12 @@ It replaces an earlier command-line project, also called [PhotoDB](https://githu
 
 ## Installing PhotoDB
 
-### From source
+There are several ways of installing PhotoDB, depending on your needs:
 
-This method of installation is required if you want to work on the source code. To install PhotoDB from source, clone this repo and run
-these steps to create a virtualenv with all the dependencies:
-
-```sh
-git clone https://github.com/djjudas21/photodb.git
-cd photodb
-virtualenv venv
-source venv/bin/activate
-pip install .
-```
-
-PhotoDB will run out of the box with no additional configuration, by creating an SQLite database in its own directory.
-
-If you wish to use an external database then copy `photodb/local_settings/local_settings.py.template` to
-`photodb/local_settings/local_settings.py` and customise the database settings for your environment.
-
-After the database is configured, apply the migrations and create your user account:
-
-```sh
-python manage.py migrate
-python manage.py createsuperuser
-```
-
-To run PhotoDB, run:
-
-```sh
-python manage.py runserver
-```
-
-and navigate to [http://localhost:8000](http://localhost:8000). Log in with the superuser account you created above.
-
-### With Docker
-
-To create a named container running PhotoDB, use the following command. You can change the `-p` settings
-if you wish to serve PhotoDB on a different port.
-
-A persistent volume will be created to store the SQLite database file.
-
-To provide additional config, e.g. [connection info for external databases](https://docs.djangoproject.com/en/2.2/ref/settings/#databases),
-create a config file `~/photodb/local_settings.py` with your settings in. This will be mounted into the container.
-
-```sh
-docker create --name photodb --mount source=photodb-sqlite,target=/var/www/photodb/db -v "$HOME/photodb":/var/www/photodb/photodb/local_settings -p 8000:8000 djjudas21/photodb
-```
-
-Start PhotoDB by running:
-
-```sh
-docker start photodb
-```
-
-and navigate to [http://localhost:8000](http://localhost:8000). Login with default username `admin` and password `admin`.
+* With Pip
+* [From source](docs/INSTALL_SOURCE.md)
+* [With Docker](docs/INSTALL-DOCKER.md)
+* [With Kubernetes](docs/INSTALL-KUBERNETES.md)
 
 ## See also
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -1,0 +1,25 @@
+# Installing with Docker
+
+Running PhotoDB with Docker is a simple choice if you simply want to use PhotoDB for yourself and don't want to make changes to the code.
+
+This guide assumes you already have an installation of Docker on your system. If not, follow [these instructions](https://docs.docker.com/install/) first.
+
+To create a named container running PhotoDB, use the following command. You can change the `-p` settings
+if you wish to serve PhotoDB on a different port.
+
+A persistent volume will be created to store the SQLite database file.
+
+To provide additional config, e.g. [connection info for external databases](https://docs.djangoproject.com/en/2.2/ref/settings/#databases),
+create a config file `~/photodb/local_settings.py` with your settings in. This will be mounted into the container.
+
+```sh
+docker create --name photodb --mount source=photodb-sqlite,target=/var/www/photodb/db -v "$HOME/photodb":/var/www/photodb/photodb/local_settings -p 8000:8000 djjudas21/photodb
+```
+
+Start PhotoDB by running:
+
+```sh
+docker start photodb
+```
+
+and navigate to [http://localhost:8000](http://localhost:8000). Login with default username `admin` and password `admin`.

--- a/docs/INSTALL-KUBERNETES.md
+++ b/docs/INSTALL-KUBERNETES.md
@@ -1,0 +1,27 @@
+# Installing with Kubernetes
+
+_Note: these instructions are a work in progress_
+
+Running PhotoDB with Kubernetes is a powerful but complex choice if you want to run PhotoDB in the cloud, at scale.
+
+This guide assumes you already have a Kubernetes cluster available.
+
+It is recommended that you install PhotoDB into its own namespace, and not into `default`.
+
+This project contains a directory of Kubernetes manifests which set up a single pod deployment of PhotoDB which uses a persistent volume
+to store its data in SQLite. This is obviously not production-ready, and work is ongoing to engineer this properly.
+
+To install PhotoDB into Kubernetes, run this
+
+```sh
+cd kubernetes
+kubectl apply -f .
+```
+
+Run the following command to get the IP address that PhotoDB is running on:
+
+```sh
+kubectl get -o jsonpath="{.spec.clusterIP}" service photodb
+```
+
+Then navigate to it by IP address, like [http://1.2.3.4:8000](http://1.2.3.4:8000). Login with default username `admin` and password `admin`.

--- a/docs/INSTALL-SOURCE.md
+++ b/docs/INSTALL-SOURCE.md
@@ -1,0 +1,32 @@
+# Installing from source
+
+This method of installation is required if you want to work on the source code. To install PhotoDB from source, clone this repo and run
+these steps to create a virtualenv with all the dependencies:
+
+```sh
+git clone https://github.com/djjudas21/photodb.git
+cd photodb
+virtualenv venv
+source venv/bin/activate
+pip install .
+```
+
+PhotoDB will run out of the box with no additional configuration, by creating an SQLite database in its own directory.
+
+If you wish to use an external database then copy `photodb/local_settings/local_settings.py.template` to
+`photodb/local_settings/local_settings.py` and customise the database settings for your environment.
+
+After the database is configured, apply the migrations and create your user account:
+
+```sh
+python manage.py migrate
+python manage.py createsuperuser
+```
+
+To run PhotoDB, run:
+
+```sh
+python manage.py runserver
+```
+
+and navigate to [http://localhost:8000](http://localhost:8000). Log in with the superuser account you created above.

--- a/kubernetes/deployment.apps_photodb.yaml
+++ b/kubernetes/deployment.apps_photodb.yaml
@@ -37,15 +37,15 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /mnt
-          name: hostpath-volume
+        - mountPath: /var/www/photodb/db
+          name: sqlite-volume
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: hostpath-volume
+      - name: sqlite-volume
         persistentVolumeClaim:
-          claimName: photodb
+          claimName: photodb-sqlite
 status: {}

--- a/kubernetes/deployment.apps_photodb.yaml
+++ b/kubernetes/deployment.apps_photodb.yaml
@@ -2,7 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    deployment.kubernetes.io/revision: "1"
+    deployment.kubernetes.io/revision: "2"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"creationTimestamp":null,"generation":1,"labels":{"app":"photodb"},"name":"photodb","namespace":"photodb","selfLink":"/apis/apps/v1/namespaces/photodb/deployments/photodb"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app":"photodb"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"photodb"}},"spec":{"containers":[{"image":"djjudas21/photodb:0.1.0","imagePullPolicy":"IfNotPresent","name":"photodb","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/mnt","name":"hostpath-volume"}]}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"name":"hostpath-volume","persistentVolumeClaim":{"claimName":"photodb"}}]}}},"status":{}}
   creationTimestamp: null
   generation: 1
   labels:
@@ -35,8 +37,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - name: hostpath-volume
-          mountPath: "/mnt"
+        - mountPath: /mnt
+          name: hostpath-volume
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/kubernetes/deployment.apps_photodb.yaml
+++ b/kubernetes/deployment.apps_photodb.yaml
@@ -34,9 +34,16 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - name: hostpath-volume
+          mountPath: "/mnt"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+      volumes:
+      - name: hostpath-volume
+        persistentVolumeClaim:
+          claimName: photodb
 status: {}

--- a/kubernetes/deployment.apps_photodb.yaml
+++ b/kubernetes/deployment.apps_photodb.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: null
+  generation: 1
+  labels:
+    app: photodb
+  name: photodb
+  selfLink: /apis/apps/v1/namespaces/photodb/deployments/photodb
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: photodb
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: photodb
+    spec:
+      containers:
+      - image: djjudas21/photodb:0.1.0
+        imagePullPolicy: IfNotPresent
+        name: photodb
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/kubernetes/deployment.apps_photodb.yaml
+++ b/kubernetes/deployment.apps_photodb.yaml
@@ -1,16 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "2"
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"creationTimestamp":null,"generation":1,"labels":{"app":"photodb"},"name":"photodb","namespace":"photodb","selfLink":"/apis/apps/v1/namespaces/photodb/deployments/photodb"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app":"photodb"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"photodb"}},"spec":{"containers":[{"image":"djjudas21/photodb:0.1.0","imagePullPolicy":"IfNotPresent","name":"photodb","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/mnt","name":"hostpath-volume"}]}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"name":"hostpath-volume","persistentVolumeClaim":{"claimName":"photodb"}}]}}},"status":{}}
-  creationTimestamp: null
-  generation: 1
   labels:
     app: photodb
   name: photodb
-  selfLink: /apis/apps/v1/namespaces/photodb/deployments/photodb
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -30,7 +23,7 @@ spec:
         app: photodb
     spec:
       containers:
-      - image: djjudas21/photodb:0.1.0
+      - image: djjudas21/photodb
         imagePullPolicy: IfNotPresent
         name: photodb
         resources: {}
@@ -48,4 +41,3 @@ spec:
       - name: sqlite-volume
         persistentVolumeClaim:
           claimName: photodb-sqlite
-status: {}

--- a/kubernetes/persistentvolumeclaim_photodb.yaml
+++ b/kubernetes/persistentvolumeclaim_photodb.yaml
@@ -1,25 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-    control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"dad7b298-f4a3-11e9-b054-9afc3b9987bc","leaseDurationSeconds":15,"acquireTime":"2019-10-22T10:20:07Z","renewTime":"2019-10-22T10:20:09Z","leaderTransitions":0}'
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"photodb","namespace":"photodb"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100M"}},"volumeMode":"Filesystem"}}
-    pv.kubernetes.io/bind-completed: "yes"
-    pv.kubernetes.io/bound-by-controller: "yes"
-    volume.beta.kubernetes.io/storage-provisioner: microk8s.io/hostpath
-  creationTimestamp: null
-  finalizers:
-  - kubernetes.io/pvc-protection
   name: photodb-sqlite
-  selfLink: /api/v1/namespaces/photodb/persistentvolumeclaims/photodb
 spec:
   accessModes:
   - ReadWriteOnce
+  volumeMode: Filesystem
   resources:
     requests:
       storage: 100M
-  storageClassName: microk8s-hostpath
-  volumeMode: Filesystem
-  volumeName: pvc-3a15c0a1-2d59-47f9-bfdd-0d894b328992
-status: {}

--- a/kubernetes/persistentvolumeclaim_photodb.yaml
+++ b/kubernetes/persistentvolumeclaim_photodb.yaml
@@ -11,7 +11,7 @@ metadata:
   creationTimestamp: null
   finalizers:
   - kubernetes.io/pvc-protection
-  name: photodb
+  name: photodb-sqlite
   selfLink: /api/v1/namespaces/photodb/persistentvolumeclaims/photodb
 spec:
   accessModes:

--- a/kubernetes/persistentvolumeclaim_photodb.yaml
+++ b/kubernetes/persistentvolumeclaim_photodb.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"dad7b298-f4a3-11e9-b054-9afc3b9987bc","leaseDurationSeconds":15,"acquireTime":"2019-10-22T10:20:07Z","renewTime":"2019-10-22T10:20:09Z","leaderTransitions":0}'
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"photodb","namespace":"photodb"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100M"}},"volumeMode":"Filesystem"}}
+    pv.kubernetes.io/bind-completed: "yes"
+    pv.kubernetes.io/bound-by-controller: "yes"
+    volume.beta.kubernetes.io/storage-provisioner: microk8s.io/hostpath
+  creationTimestamp: null
+  finalizers:
+  - kubernetes.io/pvc-protection
+  name: photodb
+  selfLink: /api/v1/namespaces/photodb/persistentvolumeclaims/photodb
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100M
+  storageClassName: microk8s-hostpath
+  volumeMode: Filesystem
+  volumeName: pvc-3a15c0a1-2d59-47f9-bfdd-0d894b328992
+status: {}

--- a/kubernetes/service_photodb.yaml
+++ b/kubernetes/service_photodb.yaml
@@ -1,11 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     app: photodb
   name: photodb
-  selfLink: /api/v1/namespaces/photodb/services/photodb
 spec:
   externalTrafficPolicy: Cluster
   ports:
@@ -16,5 +14,3 @@ spec:
     app: photodb
   sessionAffinity: None
   type: NodePort
-status:
-  loadBalancer: {}

--- a/kubernetes/service_photodb.yaml
+++ b/kubernetes/service_photodb.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: photodb
+  name: photodb
+  selfLink: /api/v1/namespaces/photodb/services/photodb
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: photodb
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/photodb/settings.py
+++ b/photodb/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'j257bf@$mm807k1l#$y=9ru9jyk2e_2aply-g6uiw=7bbc2o_p'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition


### PR DESCRIPTION
Add basic Kubernetes support, although limited at first. This provides documentation and a set of Kubernetes manifests to allow PhotoDB to be run as a single-replica app with an SQLite backend. This limitation will be addressed in #113 

Fixes #112 