### PR TITLE
Run migrations on container startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ build
 dist
 kubernetes
 venv
+db/db.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,6 @@ ENV UWSGI_STATIC_MAP="/static/=/var/www/camerahub/static/" UWSGI_STATIC_EXPIRES_
 # Run migrations
 RUN python manage.py migrate
 
-# Create superuser
-RUN python manage.py createsuperuserwithpassword --username admin --password admin --email admin@example.com --preserve
-
 # Server
 EXPOSE 8000
 STOPSIGNAL SIGINT

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV UWSGI_STATIC_MAP="/static/=/var/www/camerahub/static/" UWSGI_STATIC_EXPIRES_
 # ENV UWSGI_ROUTE_HOST="^(?!localhost:8000$) break:400"
 
 # Run migrations
-RUN python manage.py migrate
+ENV DJANGO_MANAGEPY_MIGRATE=on
 
 # Server
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ CameraHub requires no additional config to run with default settings. However it
 The following environment variables are supported:
 
 * `SECRET_KEY` - a large random value to be kept secret. Generate [here](https://miniwebtool.com/django-secret-key-generator/)
+* `ADMIN_PASSWORD` - the value of the password for the `admin` account. Defaults to `admin`
 * `DJANGO_PROD` - set to `true` to enable production mode. Defaults to `false` when running from source and `true` when running in Docker
 * `DB_ENGINE` - the database engine (default `django.db.backends.sqlite3`)
 * `DB_NAME` - the name of the database schema, or path to the SQLite db file (default `db/db.sqlite3`)

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -43,7 +43,6 @@ INSTALLED_APPS = [
     'schema.apps.SchemaConfig',
     'djmoney',
     'favicon',
-    'django_createsuperuserwithpassword',
     'django_tables2',
     'accounts.apps.AccountsConfig',
     'crispy_forms',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ sqlparse>=0.3.0,<1.0.0
 django-money>=0.15,<1.0
 django-choices>=1.7.0,<2.0.0
 django-favicon>=0.1.3,<1.0.0
-django-createsuperuserwithpassword>=2.0.0,<3.0.0
 psycopg2>=2.8.0,<3.0.0
 PyMySQL>=0.9.0,<1.0.0
 django-currentuser>=0.4.0,<0.5.0

--- a/schema/migrations/0020_create_superuser.py
+++ b/schema/migrations/0020_create_superuser.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+from django.db import migrations, models
+from django.contrib.auth.models import User     # where User lives
+import os                                      # env var accessA
+
+def forwards_func(apps, schema_editor):
+    # build the user you now have access to via Django magic
+    #User.objects.create_superuser('admin', os.getenv('ADMIN_PASSWORD')
+    User.objects.create_superuser('admin', email='admin@example.com', password='admin')
+
+def reverse_func(apps, schema_editor):
+    # destroy what forward_func builds
+    pass
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('schema', '0019_auto_20200110_1728_squashed_0020_auto_20200110_1734'),
+    ]
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]

--- a/schema/migrations/0020_create_superuser.py
+++ b/schema/migrations/0020_create_superuser.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 from django.db import migrations, models
-from django.contrib.auth.models import User     # where User lives
-import os                                      # env var accessA
+from django.contrib.auth.models import User
+import os
+from getenv import env
 
 def forwards_func(apps, schema_editor):
-    # build the user you now have access to via Django magic
-    #User.objects.create_superuser('admin', os.getenv('ADMIN_PASSWORD')
-    User.objects.create_superuser('admin', email='admin@example.com', password='admin')
+    User.objects.create_superuser('admin', email='admin@example.com', password=env('ADMIN_PASSWORD', 'admin'))
 
 def reverse_func(apps, schema_editor):
     # destroy what forward_func builds


### PR DESCRIPTION
* Run migrations on container startup, not container build
* Don't package our local dev sqlite db as it probably contains garbage test data
* Create superuser via migration, instead of command line
* Allow setting of admin password by env var

Fixes #174 