### PR TITLE
Hostname and domain fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following environment variables are supported:
 | `CAMERAHUB_PROD`           | enable [Django production mode](https://docs.djangoproject.com/en/3.0/ref/settings/#debug)       | `true` when in Docker, `false` otherwise |
 | `CAMERAHUB_SECRET_KEY`     | random secret value. Generate [here](https://miniwebtool.com/django-secret-key-generator/)       | `OverrideMe!`                            |
 | `CAMERAHUB_SENDGRID_KEY`   | API key for Sendgrid email backend                                                               |                                          |
+| `CAMERAHUB_FROM_EMAIL`     | [from email address](https://docs.djangoproject.com/en/3.0/ref/settings/#default-from-email)     | `noreply@camerahub.info`                 |
+| `CAMERAHUB_DOMAIN`         | [site domain](https://docs.djangoproject.com/en/3.0/ref/settings/#allowed-hosts)                 | `camerahub.info`                         |
 
 ## See also
 

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -149,6 +149,9 @@ LOGOUT_REDIRECT_URL = 'index'
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # Email support with Sendgrid
+DEFAULT_FROM_EMAIL = env('CAMERAHUB_FROM_EMAIL', "noreply@camerahub.info"),
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
+
 if env('CAMERAHUB_SENDGRID_KEY'):
     EMAIL_BACKEND = "sendgrid_backend.SendgridBackend"
     SENDGRID_API_KEY = env('CAMERAHUB_SENDGRID_KEY')

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'django_tables2',
     'crispy_forms',
     'moderation',
+    'fullurl',
 ]
 
 MIDDLEWARE = [
@@ -72,7 +73,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.request',
             ],
             'loaders': [
                 'django.template.loaders.filesystem.Loader',

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = env('CAMERAHUB_SECRET_KEY', 'OverrideMe!'),
 # SECURITY WARNING: don't run with debug turned on in production!
 if os.getenv('CAMERAHUB_PROD') == 'true':
     DEBUG = False
-    ALLOWED_HOSTS = ['*']
+    ALLOWED_HOSTS = [env('CAMERAHUB_DOMAIN', 'camerahub.info')]
 else:
     DEBUG = True
     ALLOWED_HOSTS = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ django-sendgrid-v5>=0.7.0,<1.0.0
 pbr>=5.0.0,<6.0.0
 django-registration>=3.0.0,<4.0.0
 django-moderation>=0.7.0,<1.0.0
+django-fullurl>=1.0,<2.0

--- a/templates/django_registration/activation_email_body.txt
+++ b/templates/django_registration/activation_email_body.txt
@@ -1,7 +1,9 @@
+{% load fullurl %}
+
 You're receiving this email because you registered for an account at CameraHub.
 
 Please go to the following page to activate your account:
 
-{{ scheme }}://{{ site}}{% url 'django_registration_activate' activation_key %}
+{% fullurl 'django_registration_activate' activation_key %}
 
 Thanks for using CameraHub!


### PR DESCRIPTION
* Make Django be aware of its own hostname/domain
* Set "from" email address
* Use absolute URL in email templates

Fixes #189 