### PR TITLE
Improve forms for cameramodel and lensmodel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-currentuser>=0.4.0,<0.5.0
 uWSGI>=2.0.0,<3.0.0
 django-getenv>=1.3.2,<2.0.0
 django-tables2>=2.1.1,<3.0.0
-django-crispy-forms>1.8.0,<2.0.0
+django-crispy-forms>=1.9.0,<2.0.0
 django-autosequence>=0.6.0,<1.0.0
 django-sendgrid-v5>=0.7.0,<1.0.0
 pbr>=5.0.0,<6.0.0

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django_currentuser.middleware import (get_current_user, get_current_authenticated_user)
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit, Div, Row, Button
-from crispy_forms.bootstrap import FormActions
+from crispy_forms.bootstrap import FormActions, AppendedText, InlineCheckboxes
 import sys
 
 from schema.models import Accessory, Archive, Battery, BulkFilm, Camera, CameraModel, Developer, Enlarger, FilmStock, Filter
@@ -149,12 +149,12 @@ class CameraModelForm(ModelForm):
             Fieldset(
                 'Physical',
                 'body_type',
-                'weight',
+                AppendedText('weight', 'g'),
             ),
             Fieldset(
                 'Focus',
                 'focus_type',
-                'viewfinder_coverage',
+                AppendedText('viewfinder_coverage', '%'),
                 'af_points',
             ),
             Fieldset(
@@ -162,8 +162,8 @@ class CameraModelForm(ModelForm):
                 'metering',
                 'coupled_metering',
                 'metering_type',
-                'metering_modes',
-                'exposure_programs',
+                InlineCheckboxes('metering_modes'),
+                InlineCheckboxes('exposure_programs'),
                 'min_iso',
                 'max_iso',
                 'meter_min_ev',
@@ -173,7 +173,7 @@ class CameraModelForm(ModelForm):
                 'Shutter',
                 'shutter_type',
                 'shutter_model',
-                'shutter_speeds',
+                InlineCheckboxes('shutter_speeds'),
                 'bulb',
                 'time',
             ),
@@ -197,7 +197,7 @@ class CameraModelForm(ModelForm):
                 'dof_preview',
                 'tripod',
                 'power_drive',
-                'continuous_fps',
+                AppendedText('continuous_fps', 'fps'),
             ),
             Fieldset(
                 'Misc',

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django_currentuser.middleware import (get_current_user, get_current_authenticated_user)
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit, Div, Row, Button
-from crispy_forms.bootstrap import FormActions
+from crispy_forms.bootstrap import FormActions, AppendedText, InlineCheckboxes
 import sys
 
 from schema.models import Accessory, Archive, Battery, BulkFilm, Camera, CameraModel, Developer, Enlarger, FilmStock, Filter
@@ -86,10 +86,6 @@ class BulkFilmForm(ModelForm):
         self.helper.layout.append(Submit('Save', 'Save'))
 
 class CameraForm(ModelForm):
-    def __init__(self, *args, **kwargs):
-        super(CameraForm, self).__init__(*args, **kwargs)
-        self.fields['lens'].queryset = Lens.objects.filter(owner = get_current_user())
-        self.fields['display_lens'].queryset = Lens.objects.filter(owner = get_current_user())
     class Meta:
         model = Camera
         fields = [
@@ -113,72 +109,96 @@ class CameraForm(ModelForm):
             fields.remove('cameramodel')
     def __init__(self, *args, **kwargs):
         super(CameraForm, self).__init__(*args, **kwargs)
+        self.fields['lens'].queryset = Lens.objects.filter(owner = get_current_user())
+        self.fields['display_lens'].queryset = Lens.objects.filter(owner = get_current_user())
         self.helper = FormHelper(self)
         self.helper.layout.append(Submit('Save', 'Save'))
 
 class CameraModelForm(ModelForm):
     class Meta:
         model = CameraModel
-        fields = [
-            'manufacturer',
-            'model',
-            'disambiguation',
-            'mount',
-            'format',
-            'focus_type',
-            'metering',
-            'coupled_metering',
-            'metering_type',
-            'introduced',
-            'discontinued',
-            'body_type',
-            'weight',
-            'introduced',
-            'discontinued',
-            'negative_size',
-            'shutter_type',
-            'shutter_model',
-            'cable_release',
-            'viewfinder_coverage',
-            'power_drive',
-            'continuous_fps',
-            'fixed_mount',
-            'lensmodel',
-            'battery_qty',
-            'battery_type',
-            'notes',
-            'bulb',
-            'time',
-            'min_iso',
-            'max_iso',
-            'af_points',
-            'int_flash',
-            'int_flash_gn',
-            'ext_flash',
-            'flash_metering',
-            'pc_sync',
-            'shoe',
-            'meter_min_ev',
-            'meter_max_ev',
-            'dof_preview',
-            'tripod',
-            'shutter_speeds',
-            'metering_modes',
-            'exposure_programs',
-            'series',
-        ]
-        if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
-            fields.remove('manufacturer')
-            fields.remove('mount')
-            fields.remove('format')
-            fields.remove('battery_type')
-            fields.remove('negative_size')
-            fields.remove('lensmodel')
-            fields.remove('flash_metering')
+        fields = '__all__'
     def __init__(self, *args, **kwargs):
         super(CameraModelForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
-        self.helper.layout.append(Submit('Save', 'Save'))
+
+        self.helper.layout = Layout(
+            Fieldset(
+                'Basics',
+                'manufacturer',
+                'model',
+                'disambiguation',
+                'introduced',
+                'discontinued',
+                'mount',
+                'fixed_mount',
+                'lensmodel',
+                'format',
+                'negative_size',
+            ),
+            Fieldset(
+                'Physical',
+                'body_type',
+                AppendedText('weight', 'g'),
+            ),
+            Fieldset(
+                'Focus',
+                'focus_type',
+                AppendedText('viewfinder_coverage', '%'),
+                'af_points',
+            ),
+            Fieldset(
+                'Metering',
+                'metering',
+                'coupled_metering',
+                'metering_type',
+                InlineCheckboxes('metering_modes'),
+                InlineCheckboxes('exposure_programs'),
+                'min_iso',
+                'max_iso',
+                'meter_min_ev',
+                'meter_max_ev',
+            ),
+            Fieldset(
+                'Shutter',
+                'shutter_type',
+                'shutter_model',
+                InlineCheckboxes('shutter_speeds'),
+                'bulb',
+                'time',
+            ),
+            Fieldset(
+                'Flash',
+                'int_flash',
+                'int_flash_gn',
+                'ext_flash',
+                'flash_metering',
+                'pc_sync',
+                'shoe',
+            ),
+            Fieldset(
+                'Battery',
+                'battery_qty',
+                'battery_type',
+            ),
+            Fieldset(
+                'Features',
+                'cable_release',
+                'dof_preview',
+                'tripod',
+                'power_drive',
+                AppendedText('continuous_fps', 'fps'),
+            ),
+            Fieldset(
+                'Misc',
+                'notes',
+                'series',
+            ),
+            FormActions(
+                Submit('save', 'Save changes'),
+                Button('cancel', 'Cancel')
+            )
+        )
 
 class DeveloperForm(ModelForm):
     class Meta:

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -118,14 +118,6 @@ class CameraModelForm(ModelForm):
     class Meta:
         model = CameraModel
         fields = '__all__'
-        if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
-            fields.remove('manufacturer')
-            fields.remove('mount')
-            fields.remove('format')
-            fields.remove('battery_type')
-            fields.remove('negative_size')
-            fields.remove('lensmodel')
-            fields.remove('flash_metering')
     def __init__(self, *args, **kwargs):
         super(CameraModelForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -119,54 +119,7 @@ class CameraForm(ModelForm):
 class CameraModelForm(ModelForm):
     class Meta:
         model = CameraModel
-        fields = [
-            'manufacturer',
-            'model',
-            'disambiguation',
-            'mount',
-            'format',
-            'focus_type',
-            'metering',
-            'coupled_metering',
-            'metering_type',
-            'introduced',
-            'discontinued',
-            'body_type',
-            'weight',
-            'introduced',
-            'discontinued',
-            'negative_size',
-            'shutter_type',
-            'shutter_model',
-            'cable_release',
-            'viewfinder_coverage',
-            'power_drive',
-            'continuous_fps',
-            'fixed_mount',
-            'lensmodel',
-            'battery_qty',
-            'battery_type',
-            'notes',
-            'bulb',
-            'time',
-            'min_iso',
-            'max_iso',
-            'af_points',
-            'int_flash',
-            'int_flash_gn',
-            'ext_flash',
-            'flash_metering',
-            'pc_sync',
-            'shoe',
-            'meter_min_ev',
-            'meter_max_ev',
-            'dof_preview',
-            'tripod',
-            'shutter_speeds',
-            'metering_modes',
-            'exposure_programs',
-            'series',
-        ]
+        fields = '__all__'
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
             fields.remove('mount')
@@ -178,7 +131,84 @@ class CameraModelForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(CameraModelForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
-        self.helper.layout.append(Submit('Save', 'Save'))
+
+        self.helper.layout = Layout(
+            Fieldset(
+                'Basics',
+                'manufacturer',
+                'model',
+                'disambiguation',
+                'introduced',
+                'discontinued',
+                'mount',
+                'fixed_mount',
+                'lensmodel',
+                'format',
+                'negative_size',
+            ),
+            Fieldset(
+                'Physical',
+                'body_type',
+                'weight',
+            ),
+            Fieldset(
+                'Focus',
+                'focus_type',
+                'viewfinder_coverage',
+                'af_points',
+            ),
+            Fieldset(
+                'Metering',
+                'metering',
+                'coupled_metering',
+                'metering_type',
+                'metering_modes',
+                'exposure_programs',
+                'min_iso',
+                'max_iso',
+                'meter_min_ev',
+                'meter_max_ev',
+            ),
+            Fieldset(
+                'Shutter',
+                'shutter_type',
+                'shutter_model',
+                'shutter_speeds',
+                'bulb',
+                'time',
+            ),
+            Fieldset(
+                'Flash',
+                'int_flash',
+                'int_flash_gn',
+                'ext_flash',
+                'flash_metering',
+                'pc_sync',
+                'shoe',
+            ),
+            Fieldset(
+                'Battery',
+                'battery_qty',
+                'battery_type',
+            ),
+            Fieldset(
+                'Features',
+                'cable_release',
+                'dof_preview',
+                'tripod',
+                'power_drive',
+                'continuous_fps',
+            ),
+            Fieldset(
+                'Misc',
+                'notes',
+                'series',
+            ),
+            FormActions(
+                Submit('save', 'Save changes'),
+                Button('cancel', 'Cancel')
+            )
+        )
 
 class DeveloperForm(ModelForm):
     class Meta:

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django_currentuser.middleware import (get_current_user, get_current_authenticated_user)
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit, Div, Row, Button
-from crispy_forms.bootstrap import FormActions, AppendedText, InlineCheckboxes
+from crispy_forms.bootstrap import FormActions, AppendedText, InlineCheckboxes, PrependedText
 import sys
 
 from schema.models import Accessory, Archive, Battery, BulkFilm, Camera, CameraModel, Developer, Enlarger, FilmStock, Filter
@@ -367,51 +367,62 @@ class LensForm(ModelForm):
 class LensModelForm(ModelForm):
     class Meta:
         model = LensModel
-        fields = [
-            'manufacturer',
-            'model',
-            'disambiguation',
-            'mount',
-            'zoom',
-            'min_focal_length',
-            'max_focal_length',
-            'closest_focus',
-            'max_aperture',
-            'min_aperture',
-            'elements',
-            'groups',
-            'weight',
-            'nominal_min_angle_diag',
-            'nominal_max_angle_diag',
-            'aperture_blades',
-            'autofocus',
-            'filter_thread',
-            'magnification',
-            'url',
-            'introduced',
-            'discontinued',
-            'negative_size',
-            'fixed_mount',
-            'notes',
-            'coating',
-            'hood',
-            'exif_lenstype',
-            'rectilinear',
-            'length',
-            'diameter',
-            'image_circle',
-            'formula',
-            'shutter_model',
-            'series',
-        ]
-        if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
-            fields.remove('manufacturer')
-            fields.remove('mount')
-            fields.remove('negative_size')
+        fields = '__all__'
     def __init__(self, *args, **kwargs):
         super(LensModelForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
-        self.helper.layout.append(Submit('Save', 'Save'))
+        self.helper.layout = Layout(
+            Fieldset(
+                'Basics',
+                'manufacturer',
+                'model',
+                'disambiguation',
+                'fixed_mount',
+                'mount',
+                'introduced',
+                'discontinued',
+            ),
+            Fieldset(
+                'Optics',
+                'zoom',
+                AppendedText('min_focal_length', 'mm'),
+                AppendedText('max_focal_length', 'mm'),
+                AppendedText('closest_focus', 'cm'),
+                PrependedText('max_aperture', 'f/'),
+                PrependedText('min_aperture', 'f/'),
+                'elements',
+                'groups',
+                AppendedText('nominal_min_angle_diag', '&deg;'),
+                AppendedText('nominal_max_angle_diag', '&deg;'),
+                'rectilinear',
+                AppendedText('image_circle', 'mm'),
+                'formula',
+                'aperture_blades',
+                'autofocus',
+                AppendedText('magnification', '&times;'),
+                'negative_size',
+            ),
+            Fieldset(
+                'Physical',
+                AppendedText('weight', 'g'),
+                AppendedText('length', 'mm'),
+                AppendedText('diameter', 'mm'),
+                AppendedText('filter_thread', 'mm'),
+                'hood',
+                'shutter_model',
+            ),
+            Fieldset(
+                'Misc',
+                'notes',
+                'exif_lenstype',
+                'url',
+                'series',
+            ),
+            FormActions(
+                Submit('save', 'Save changes'),
+                Button('cancel', 'Cancel')
+            )
+        )   
 
 class ManufacturerForm(ModelForm):
     class Meta:

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -1,6 +1,9 @@
 from django.forms import ModelForm
 from django import forms
 from django_currentuser.middleware import (get_current_user, get_current_authenticated_user)
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit, Div, Row, Button
+from crispy_forms.bootstrap import FormActions
 import sys
 
 from schema.models import Accessory, Archive, Battery, BulkFilm, Camera, CameraModel, Developer, Enlarger, FilmStock, Filter
@@ -26,6 +29,10 @@ class AccessoryForm(ModelForm):
             fields.remove('manufacturer')
             fields.remove('camera_model_compatibility')
             fields.remove('lens_model_compatibility')
+    def __init__(self, *args, **kwargs):
+        super(AccessoryForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class ArchiveForm(ModelForm):
     class Meta:
@@ -39,6 +46,10 @@ class ArchiveForm(ModelForm):
             'storage',
             'sealed',
         ]
+    def __init__(self, *args, **kwargs):
+        super(ArchiveForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class BatteryForm(ModelForm):
     class Meta:
@@ -49,6 +60,10 @@ class BatteryForm(ModelForm):
             'chemistry',
             'other_names',
         ]
+    def __init__(self, *args, **kwargs):
+        super(BatteryForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class BulkFilmForm(ModelForm):
     class Meta:
@@ -65,6 +80,10 @@ class BulkFilmForm(ModelForm):
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('filmstock')
             fields.remove('format')
+    def __init__(self, *args, **kwargs):
+        super(BulkFilmForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class CameraForm(ModelForm):
     def __init__(self, *args, **kwargs):
@@ -92,6 +111,10 @@ class CameraForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('cameramodel')
+    def __init__(self, *args, **kwargs):
+        super(CameraForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class CameraModelForm(ModelForm):
     class Meta:
@@ -152,6 +175,10 @@ class CameraModelForm(ModelForm):
             fields.remove('negative_size')
             fields.remove('lensmodel')
             fields.remove('flash_metering')
+    def __init__(self, *args, **kwargs):
+        super(CameraModelForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class DeveloperForm(ModelForm):
     class Meta:
@@ -165,6 +192,10 @@ class DeveloperForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
+    def __init__(self, *args, **kwargs):
+        super(DeveloperForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class EnlargerForm(ModelForm):
     class Meta:
@@ -185,6 +216,10 @@ class EnlargerForm(ModelForm):
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
             fields.remove('negative_size')
+    def __init__(self, *args, **kwargs):
+        super(EnlargerForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class FilmStockForm(ModelForm):
     class Meta:
@@ -200,6 +235,10 @@ class FilmStockForm(ModelForm):
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
             fields.remove('process')
+    def __init__(self, *args, **kwargs):
+        super(FilmStockForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class FilterForm(ModelForm):
     class Meta:
@@ -213,6 +252,10 @@ class FilterForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
+    def __init__(self, *args, **kwargs):
+        super(FilterForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class FlashForm(ModelForm):
     class Meta:
@@ -243,6 +286,10 @@ class FlashForm(ModelForm):
             fields.remove('manufacturer')
             fields.remove('flash_protocol')
             fields.remove('battery_type')
+    def __init__(self, *args, **kwargs):
+        super(FlashForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class FlashProtocolForm(ModelForm):
     class Meta:
@@ -253,6 +300,10 @@ class FlashProtocolForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
+    def __init__(self, *args, **kwargs):
+        super(FlashProtocolForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class FormatForm(ModelForm):
     class Meta:
@@ -263,6 +314,10 @@ class FormatForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('negative_size')
+    def __init__(self, *args, **kwargs):
+        super(FormatForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class LensForm(ModelForm):
     class Meta:
@@ -284,6 +339,10 @@ class LensForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('lensmodel')
+    def __init__(self, *args, **kwargs):
+        super(LensForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class LensModelForm(ModelForm):
     class Meta:
@@ -329,6 +388,10 @@ class LensModelForm(ModelForm):
             fields.remove('manufacturer')
             fields.remove('mount')
             fields.remove('negative_size')
+    def __init__(self, *args, **kwargs):
+        super(LensModelForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class ManufacturerForm(ModelForm):
     class Meta:
@@ -341,6 +404,10 @@ class ManufacturerForm(ModelForm):
             'founded',
             'dissolved',
         ]
+    def __init__(self, *args, **kwargs):
+        super(ManufacturerForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class MountForm(ModelForm):
     class Meta:
@@ -355,6 +422,10 @@ class MountForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
+    def __init__(self, *args, **kwargs):
+        super(MountForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class MountAdapterForm(ModelForm):
     class Meta:
@@ -369,6 +440,10 @@ class MountAdapterForm(ModelForm):
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('camera_mount')
             fields.remove('lens_mount')
+    def __init__(self, *args, **kwargs):
+        super(MountAdapterForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class NegativeSizeForm(ModelForm):
     class Meta:
@@ -381,6 +456,10 @@ class NegativeSizeForm(ModelForm):
             'area',
             'aspect_ratio',
         ]
+    def __init__(self, *args, **kwargs):
+        super(NegativeSizeForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class OrderForm(ModelForm):
     def __init__(self, *args, **kwargs):
@@ -388,6 +467,9 @@ class OrderForm(ModelForm):
         self.fields['negative'].queryset = Negative.objects.filter(owner = get_current_user())
         self.fields['print'].queryset = Print.objects.filter(owner = get_current_user())
         self.fields['recipient'].queryset = Person.objects.filter(owner = get_current_user())
+    
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
     class Meta:
         model = Order
         fields = [
@@ -413,11 +495,19 @@ class PaperStockForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
+    def __init__(self, *args, **kwargs):
+        super(PaperStockForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class PersonForm(ModelForm):
     class Meta:
         model = Person
         fields = ['name']
+    def __init__(self, *args, **kwargs):
+        super(PersonForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class PrintForm(ModelForm):
     def __init__(self, *args, **kwargs):
@@ -427,6 +517,8 @@ class PrintForm(ModelForm):
         self.fields['lens'].queryset = Lens.objects.filter(owner = get_current_user())
         self.fields['archive'].queryset = Archive.objects.filter(owner = get_current_user())
         self.fields['printer'].queryset = Person.objects.filter(owner = get_current_user())
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
     class Meta:
         model = Print
         fields = [
@@ -464,12 +556,18 @@ class ProcessForm(ModelForm):
             'colour',
             'positive',
         ]
+    def __init__(self, *args, **kwargs):
+        super(ProcessForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class RepairForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(RepairForm, self).__init__(*args, **kwargs)
         self.fields['camera'].queryset = Camera.objects.filter(owner = get_current_user())
         self.fields['lens'].queryset = Lens.objects.filter(owner = get_current_user())
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
     class Meta:
         model = Repair
         fields = [
@@ -485,6 +583,8 @@ class ScanForm(ModelForm):
         super(ScanForm, self).__init__(*args, **kwargs)
         self.fields['negative'].queryset = Negative.objects.filter(owner = get_current_user())
         self.fields['print'].queryset = Print.objects.filter(owner = get_current_user())
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
     class Meta:
         model = Scan
         fields = [
@@ -506,6 +606,8 @@ class NegativeForm(ModelForm):
         self.fields['film'].queryset = Film.objects.filter(owner = get_current_user())
         self.fields['photographer'].queryset = Person.objects.filter(owner = get_current_user())
         self.fields['copy_of'].queryset = Negative.objects.filter(owner = get_current_user())
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
     class Meta:
         model = Negative
         fields = [
@@ -537,6 +639,8 @@ class FilmForm(ModelForm):
         self.fields['bulk_film'].queryset = BulkFilm.objects.filter(owner = get_current_user())
         self.fields['processed_by'].queryset = Person.objects.filter(owner = get_current_user())
         self.fields['archive'].queryset = Archive.objects.filter(owner = get_current_user())
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
     class Meta:
         model = Film
         fields = [
@@ -573,6 +677,10 @@ class SeriesForm(ModelForm):
     class Meta:
         model = Series
         fields = ['name']
+    def __init__(self, *args, **kwargs):
+        super(SeriesForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class TeleconverterForm(ModelForm):
     class Meta:
@@ -589,6 +697,10 @@ class TeleconverterForm(ModelForm):
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
             fields.remove('mount')
+    def __init__(self, *args, **kwargs):
+        super(TeleconverterForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))
 
 class TonerForm(ModelForm):
     class Meta:
@@ -601,3 +713,7 @@ class TonerForm(ModelForm):
         ]
         if ('makemigrations' in sys.argv or 'migrate' in sys.argv or 'test' in sys.argv):
             fields.remove('manufacturer')
+    def __init__(self, *args, **kwargs):
+        super(TonerForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.layout.append(Submit('Save', 'Save'))

--- a/schema/forms.py
+++ b/schema/forms.py
@@ -86,10 +86,6 @@ class BulkFilmForm(ModelForm):
         self.helper.layout.append(Submit('Save', 'Save'))
 
 class CameraForm(ModelForm):
-    def __init__(self, *args, **kwargs):
-        super(CameraForm, self).__init__(*args, **kwargs)
-        self.fields['lens'].queryset = Lens.objects.filter(owner = get_current_user())
-        self.fields['display_lens'].queryset = Lens.objects.filter(owner = get_current_user())
     class Meta:
         model = Camera
         fields = [
@@ -113,6 +109,8 @@ class CameraForm(ModelForm):
             fields.remove('cameramodel')
     def __init__(self, *args, **kwargs):
         super(CameraForm, self).__init__(*args, **kwargs)
+        self.fields['lens'].queryset = Lens.objects.filter(owner = get_current_user())
+        self.fields['display_lens'].queryset = Lens.objects.filter(owner = get_current_user())
         self.helper = FormHelper(self)
         self.helper.layout.append(Submit('Save', 'Save'))
 

--- a/schema/models.py
+++ b/schema/models.py
@@ -744,8 +744,6 @@ class CameraModel(models.Model):
   discontinued = models.PositiveIntegerField(help_text='Year in which the camera model was discontinued', blank=True, null=True)
   body_type = models.CharField(choices=BodyType.choices, max_length=25, blank=True, null=True, help_text='Body type of this camera model')
   weight = models.PositiveIntegerField(help_text='Weight of the camera body (without lens or batteries) in grammes (g)', blank=True, null=True)
-  introduced = models.PositiveIntegerField(help_text='Year in which the camera model was introduced', blank=True, null=True)
-  discontinued = models.PositiveIntegerField(help_text='Year in which the camera model was discontinued', blank=True, null=True)
   negative_size = models.ForeignKey(NegativeSize, on_delete=models.CASCADE, blank=True, null=True, help_text='Size of negative created by this camera')
   shutter_type = models.CharField(choices=ShutterType.choices, max_length=25, blank=True, null=True, help_text='Type of shutter used on this camera model')
   shutter_model = models.CharField(help_text='Model of shutter', max_length=45, blank=True, null=True)

--- a/schema/templates/schema/create.html
+++ b/schema/templates/schema/create.html
@@ -6,8 +6,5 @@
 {% block subheading %}<h2>Add new</h2>{%endblock%}
 
 {% block content %}
-<form method="post">{% csrf_token %}
-    {{ form|crispy }}
-    <input type="submit" value="Save">
-</form>
+{% crispy form %}
 {% endblock %}

--- a/schema/templates/schema/update.html
+++ b/schema/templates/schema/update.html
@@ -6,8 +6,5 @@
 {% block subheading %}<h2>{{ object }}</h2>{%endblock%}
 
 {% block content %}
-<form method="post">{% csrf_token %}
-    {{ form|crispy }}
-    <input type="submit" value="Update">
-</form>
+{% crispy form %}
 {% endblock %}


### PR DESCRIPTION
Improve forms for cameramodel and lensmodel by using crispy forms and organising the form fields into fieldsets.

Fixes #237 