### PR TITLE
Publish only on release events

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
     branches: [ master ]
+  release:
+    types: [ published ]
 
 jobs:
   lint:
@@ -64,7 +66,7 @@ jobs:
         tags: testing
         push: false
   publish:
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Publish to Docker Hub and PyPI only on release events, not generic tags