### PR TITLE
Hide private objects from unauthenticated users

### DIFF
--- a/schema/templates/schema/cameramodel_detail.html
+++ b/schema/templates/schema/cameramodel_detail.html
@@ -466,6 +466,7 @@
 </ul>
 {% endif %}
 
+{% if user.is_authenticated %}
 {% if cameramodel.camera_set.all %}
 <h4>Cameras</h4>
 <table class="table table-hover">
@@ -502,6 +503,7 @@
   </tr>
   {% endfor %}
 </table>
+{% endif %}
 {% endif %}
 {% endblock %}
 

--- a/schema/templates/schema/lensmodel_detail.html
+++ b/schema/templates/schema/lensmodel_detail.html
@@ -237,6 +237,7 @@
 </ul>
 {% endif %}
 
+{% if user.is_authenticated %}
 <a data-toggle="collapse" href="#collapseLenses" role="button" aria-expanded="false" aria-controls="collapseLenses">
   Lenses</a>
 <div class="collapse" id="collapseLenses">
@@ -253,6 +254,7 @@
     {% endfor %}
   </table>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block moreactions %}


### PR DESCRIPTION
Hide private objects (cameras and lenses) from unauthenticated users in public views (camera models and lens models)

Fixes #357 