### PR TITLE
Load app config to enable Watson search

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=invalid-name
+default_app_config = 'schema.apps.SchemaConfig'


### PR DESCRIPTION
Load app config to enable Watson search again after it was accidentally disabled in 5119e66b594a5ce00583cbd55c6d6a02dafb8b35

Fixes #405 