### PR TITLE
Check that user is authenticated before using the username

### DIFF
--- a/schema/views.py
+++ b/schema/views.py
@@ -244,8 +244,9 @@ class CameraModelDetail(generic.DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['related'] = self.get_object().tags.similar_objects()
-        context['mine'] = self.get_object().camera_set.filter(
-            owner=self.request.user)
+        if self.request.user.is_authenticated:
+            context['mine'] = self.get_object().camera_set.filter(
+                owner=self.request.user)
         return context
 
 
@@ -499,8 +500,9 @@ class LensModelDetail(generic.DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['related'] = self.get_object().tags.similar_objects()
-        context['mine'] = self.get_object().lens_set.filter(
-            owner=self.request.user)
+        if self.request.user.is_authenticated:
+            context['mine'] = self.get_object().lens_set.filter(
+                owner=self.request.user)
         return context
 
 


### PR DESCRIPTION
Check that user is authenticated before using the username,to prevent errors when displaying detail views to unauthenticated users

Fixes #430 