### PR TITLE
Prometheus metrics

### DIFF
--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -51,9 +51,11 @@ INSTALLED_APPS = [
     'django_filters',
     'watson',
     'taggit',
+    'django_prometheus',
 ]
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -64,6 +66,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_currentuser.middleware.ThreadLocalUserMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 ROOT_URLCONF = 'camerahub.urls'

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -99,7 +99,7 @@ WSGI_APPLICATION = 'camerahub.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': env('CAMERAHUB_DB_ENGINE', 'django.db.backends.sqlite3'),
+        'ENGINE': env('CAMERAHUB_DB_ENGINE', 'django_prometheus.db.backends.sqlite3'),
         'NAME': env('CAMERAHUB_DB_NAME', os.path.join(BASE_DIR, 'db', 'db.sqlite3')),
         'USER': env('CAMERAHUB_DB_USER'),
         'PASSWORD': env('CAMERAHUB_DB_PASS'),

--- a/camerahub/urls.py
+++ b/camerahub/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path('accounts/', include('django_registration.backends.activation.urls')),
     path('accounts/', include('django.contrib.auth.urls')),
     path('', include('favicon.urls')),
+    path('', include('django_prometheus.urls')),
 ]

--- a/kubernetes/kustomize/camerahub/deployment.yaml
+++ b/kubernetes/kustomize/camerahub/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: CAMERAHUB_DB_PORT
               value: "5432"
             - name: CAMERAHUB_DB_ENGINE
-              value: django.db.backends.postgresql
+              value: django_prometheus.db.backends.postgresql
             - name: CAMERAHUB_PROD
               valueFrom:
                 secretKeyRef:

--- a/poetry.lock
+++ b/poetry.lock
@@ -187,6 +187,17 @@ test = ["mock", "pytest (>=3.1.0)", "pytest-django", "pytest-pythonpath", "pytes
 
 [[package]]
 category = "main"
+description = "Django middlewares to monitor your application with Prometheus.io."
+name = "django-prometheus"
+optional = false
+python-versions = "*"
+version = "2.0.0"
+
+[package.dependencies]
+prometheus-client = ">=0.7"
+
+[[package]]
+category = "main"
 description = "Full featured redis cache backend for Django."
 name = "django-redis"
 optional = false
@@ -356,6 +367,17 @@ version = "0.1.5"
 
 [package.dependencies]
 tomlkit = ">=0.4.6,<0.6.0"
+
+[[package]]
+category = "main"
+description = "Python client for the Prometheus monitoring system."
+name = "prometheus-client"
+optional = false
+python-versions = "*"
+version = "0.8.0"
+
+[package.extras]
+twisted = ["twisted"]
 
 [[package]]
 category = "main"
@@ -596,7 +618,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 pgsql = ["psycopg2-binary"]
 
 [metadata]
-content-hash = "c57706f20cd24e2b41a4a99bfd66622533f71016c13d76e38302da9f13b287cb"
+content-hash = "c770868cb69e1f5398ca55a13ffc79ba2f34d49af6d486eb128236b7af1a10d3"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -660,6 +682,10 @@ django-getenv = [
 django-money = [
     {file = "django-money-0.15.1.tar.gz", hash = "sha256:88b5a0ee36565a87c39581efedbe4834b6f3f4a9a348887678ed2f45f4f8a192"},
     {file = "django_money-0.15.1-py2.py3-none-any.whl", hash = "sha256:61b06e495f5c08795504bd0f8708295e3db3649aae7db8297f1a55a9755b5611"},
+]
+django-prometheus = [
+    {file = "django-prometheus-2.0.0.tar.gz", hash = "sha256:8f25e86a3c310f40cf32cfa1b56a2b6df9cb2521e4cb794844958697d98fb3d1"},
+    {file = "django_prometheus-2.0.0-py2.py3-none-any.whl", hash = "sha256:4c30aa8eb944fcf3cf10e20dfabbbe11ad5a84fce62abb3658feffa4e2ac2b97"},
 ]
 django-redis = [
     {file = "django-redis-4.12.1.tar.gz", hash = "sha256:306589c7021e6468b2656edc89f62b8ba67e8d5a1c8877e2688042263daa7a63"},
@@ -737,6 +763,10 @@ pluggy = [
 poetry-version = [
     {file = "poetry-version-0.1.5.tar.gz", hash = "sha256:f7d77b5c4f0761c5a5b9031f199c79c7f81d125676248053ea84e69ad79faa89"},
     {file = "poetry_version-0.1.5-py2.py3-none-any.whl", hash = "sha256:ba259257640cd36c76375563a001b9e85c6f54d764cc56b3eed0f3b5cefb0317"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.8.0-py2.py3-none-any.whl", hash = "sha256:983c7ac4b47478720db338f1491ef67a100b474e3bc7dafcbaefb7d0b8f9b01c"},
+    {file = "prometheus_client-0.8.0.tar.gz", hash = "sha256:c6e6b706833a6bd1fd51711299edee907857be10ece535126a158f911ee80915"},
 ]
 psycopg2-binary = [
     {file = "psycopg2-binary-2.8.5.tar.gz", hash = "sha256:ccdc6a87f32b491129ada4b87a43b1895cf2c20fdb7f98ad979647506ffc41b6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ django-watson = "^1.5.5"
 django-redis = "^4.11"
 django-taggit = "^1"
 poetry-version = "*"
+django-prometheus = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/schema/models.py
+++ b/schema/models.py
@@ -12,6 +12,7 @@ from django_currentuser.db.models import CurrentUserField
 from autosequence.fields import AutoSequenceField
 from slugify import Slugify, UniqueSlugify
 from taggit.managers import TaggableManager
+from django_prometheus.models import ExportModelOperationsMixin
 
 
 def cameramodel_check(text, uids):
@@ -1023,7 +1024,7 @@ class Developer(models.Model):
 # Table to catalog lens models
 
 
-class LensModel(models.Model):
+class LensModel(ExportModelOperationsMixin('lensmodel'), models.Model):
     # Choices for focus type
     class CoatingType(DjangoChoices):
         Uncoated = ChoiceItem()
@@ -1195,7 +1196,7 @@ class LensModel(models.Model):
 # Table to catalog camera models - both cameras with fixed and interchangeable lenses
 
 
-class CameraModel(models.Model):
+class CameraModel(ExportModelOperationsMixin('cameramodel'), models.Model):
     # Choices for body types
     class BodyType(DjangoChoices):
         Box_camera = ChoiceItem()


### PR DESCRIPTION
Add Prometheus metrics endpoint at `/metrics` which provides data on core Django, the database backend, and selected models.

Fixes #434