### PR TITLE
Configure uwsgi from ini file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ADD . $PROJECT_DIR
 WORKDIR $PROJECT_DIR
 
 # Set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 # Install deps from apk and poetry
 RUN apk --no-cache add pcre mailcap libpq jpeg libmagic \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,22 +23,6 @@ RUN apk --no-cache add pcre mailcap libpq jpeg libmagic \
 # Call collectstatic (customize the following line with the minimal environment variables needed for manage.py to run):
 RUN python manage.py collectstatic --noinput
 
-# Tell uWSGI where to find your wsgi file:
-ENV UWSGI_WSGI_FILE=camerahub/wsgi.py
-
-# Base uWSGI configuration (you shouldn't need to change these):
-ENV UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_HTTP_AUTO_CHUNKED=1 UWSGI_HTTP_KEEPALIVE=1 UWSGI_UID=1000 UWSGI_GID=2000 UWSGI_LAZY_APPS=1 UWSGI_WSGI_ENV_BEHAVIOR=holy
-
-# Number of uWSGI workers and threads per worker (customize as needed):
-ENV UWSGI_WORKERS=2 UWSGI_THREADS=4
-
-# uWSGI static file serving configuration (customize or comment out if not needed):
-ENV UWSGI_STATIC_MAP="/static/=/var/www/camerahub/static/" UWSGI_STATIC_EXPIRES_URI="/static/.*\.[a-f0-9]{12,}\.(css|js|png|jpg|jpeg|gif|ico|woff|ttf|otf|svg|scss|map|txt) 315360000"
-ENV UWSGI_STATIC_MAP="/media/=/var/www/camerahub/media/" UWSGI_STATIC_EXPIRES_URI="/media/.*\.[a-f0-9]{12,}\.(css|js|png|jpg|jpeg|gif|ico|woff|ttf|otf|svg|scss|map|txt) 315360000"
-
-# Deny invalid hosts before they get to Django (uncomment and change to your hostname(s)):
-# ENV UWSGI_ROUTE_HOST="^(?!localhost:8000$) break:400"
-
 # Run migrations
 ENV DJANGO_MANAGEPY_MIGRATE=on
 
@@ -48,4 +32,4 @@ STOPSIGNAL SIGINT
 
 # Start uWSGI
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["uwsgi", "--show-config"]
+CMD ["uwsgi", "--ini uwsgi.ini", "--show-config"]

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,22 @@
+[uwsgi]
+lazy-apps = 1
+http-keepalive = 1
+master = 1
+uid = 1000
+wsgi-file = camerahub/wsgi.py
+wsgi-env-behavior = holy
+http = :8000
+http-auto-chunked = 1
+workers = 2
+threads = 4
+gid = 2000
+show-config = true
+
+static-map = /media/=/var/www/camerahub/media/
+static-expires-uri = /media/.*\.[a-f0-9]{12,}\.(css|js|png|jpg|jpeg|gif|ico|woff|ttf|otf|svg|scss|map|txt) 315360000
+
+static-map = /static/=/var/www/camerahub/static/
+static-expires-uri = /static/.*\.[a-f0-9]{12,}\.(css|js|png|jpg|jpeg|gif|ico|woff|ttf|otf|svg|scss|map|txt) 315360000
+
+# Deny invalid hosts before they get to Django (uncomment and change to your hostname(s)):
+# ENV UWSGI_ROUTE_HOST="^(?!localhost:8000$) break:400"


### PR DESCRIPTION
Configure uwsgi from ini file, so we can specify `static-map` multiple times, which can't be done with env vars. This is a prerequisite for #14.