### PR TITLE
Use built-in getenv() instead of env()

### DIFF
--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
-from getenv import env
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -21,12 +20,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env('CAMERAHUB_SECRET_KEY', 'OverrideMe!')
+SECRET_KEY = os.getenv('CAMERAHUB_SECRET_KEY', 'OverrideMe!')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if os.getenv('CAMERAHUB_PROD') == 'true':
     DEBUG = False
-    ALLOWED_HOSTS = [env('CAMERAHUB_DOMAIN', 'camerahub.info')]
+    ALLOWED_HOSTS = [os.getenv('CAMERAHUB_DOMAIN', 'camerahub.info')]
 else:
     DEBUG = True
     ALLOWED_HOSTS = []
@@ -102,12 +101,12 @@ WSGI_APPLICATION = 'camerahub.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': env('CAMERAHUB_DB_ENGINE', 'django_prometheus.db.backends.sqlite3'),
-        'NAME': env('CAMERAHUB_DB_NAME', os.path.join(BASE_DIR, 'db', 'db.sqlite3')),
-        'USER': env('CAMERAHUB_DB_USER'),
-        'PASSWORD': env('CAMERAHUB_DB_PASS'),
-        'HOST': env('CAMERAHUB_DB_HOST'),
-        'PORT': env('CAMERAHUB_DB_PORT'),
+        'ENGINE': os.getenv('CAMERAHUB_DB_ENGINE', 'django_prometheus.db.backends.sqlite3'),
+        'NAME': os.getenv('CAMERAHUB_DB_NAME', os.path.join(BASE_DIR, 'db', 'db.sqlite3')),
+        'USER': os.getenv('CAMERAHUB_DB_USER'),
+        'PASSWORD': os.getenv('CAMERAHUB_DB_PASS'),
+        'HOST': os.getenv('CAMERAHUB_DB_HOST'),
+        'PORT': os.getenv('CAMERAHUB_DB_PORT'),
     }
 }
 
@@ -174,20 +173,20 @@ LOGOUT_REDIRECT_URL = 'index'
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # Email support
-DEFAULT_FROM_EMAIL = env('CAMERAHUB_FROM_EMAIL', "noreply@camerahub.info")
+DEFAULT_FROM_EMAIL = os.getenv('CAMERAHUB_FROM_EMAIL', "noreply@camerahub.info")
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
-if env('CAMERAHUB_EMAIL_HOST'):
+if os.getenv('CAMERAHUB_EMAIL_HOST'):
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_USE_TLS = env('CAMERAHUB_EMAIL_USE_TLS', True)
-    EMAIL_USE_SSL = env('CAMERAHUB_EMAIL_USE_SSL', False)
-    EMAIL_HOST = env('CAMERAHUB_EMAIL_HOST')
-    EMAIL_HOST_USER = env('CAMERAHUB_EMAIL_HOST_USER')
-    EMAIL_HOST_PASSWORD = env('CAMERAHUB_EMAIL_HOST_PASSWORD')
-    EMAIL_PORT = env('CAMERAHUB_EMAIL_PORT', '587')
-elif env('CAMERAHUB_SENDGRID_KEY'):
+    EMAIL_USE_TLS = os.getenv('CAMERAHUB_EMAIL_USE_TLS', True)
+    EMAIL_USE_SSL = os.getenv('CAMERAHUB_EMAIL_USE_SSL', False)
+    EMAIL_HOST = os.getenv('CAMERAHUB_EMAIL_HOST')
+    EMAIL_HOST_USER = os.getenv('CAMERAHUB_EMAIL_HOST_USER')
+    EMAIL_HOST_PASSWORD = os.getenv('CAMERAHUB_EMAIL_HOST_PASSWORD')
+    EMAIL_PORT = os.getenv('CAMERAHUB_EMAIL_PORT', '587')
+elif os.getenv('CAMERAHUB_SENDGRID_KEY'):
     EMAIL_BACKEND = "sendgrid_backend.SendgridBackend"
-    SENDGRID_API_KEY = env('CAMERAHUB_SENDGRID_KEY')
+    SENDGRID_API_KEY = os.getenv('CAMERAHUB_SENDGRID_KEY')
 else:
     EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
     EMAIL_FILE_PATH = os.path.join(BASE_DIR, "sent_emails")
@@ -223,8 +222,8 @@ if os.getenv('CAMERAHUB_REDIS') == 'true':
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': "redis://{}:{}/1".format(
-                env('CAMERAHUB_REDIS_HOST', '127.0.0.1'),
-                env('CAMERAHUB_REDIS_PORT', '6379'),
+                os.getenv('CAMERAHUB_REDIS_HOST', '127.0.0.1'),
+                os.getenv('CAMERAHUB_REDIS_PORT', '6379'),
             ),
             'OPTIONS': {
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -178,8 +178,8 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 if os.getenv('CAMERAHUB_EMAIL_HOST'):
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_USE_TLS = os.getenv('CAMERAHUB_EMAIL_USE_TLS', True)
-    EMAIL_USE_SSL = os.getenv('CAMERAHUB_EMAIL_USE_SSL', False)
+    EMAIL_USE_TLS = os.getenv('CAMERAHUB_EMAIL_USE_TLS', 'true')
+    EMAIL_USE_SSL = os.getenv('CAMERAHUB_EMAIL_USE_SSL', 'false')
     EMAIL_HOST = os.getenv('CAMERAHUB_EMAIL_HOST')
     EMAIL_HOST_USER = os.getenv('CAMERAHUB_EMAIL_HOST_USER')
     EMAIL_HOST_PASSWORD = os.getenv('CAMERAHUB_EMAIL_HOST_PASSWORD')

--- a/poetry.lock
+++ b/poetry.lock
@@ -162,14 +162,6 @@ Django = ">=1.8"
 
 [[package]]
 category = "main"
-description = "Read settings from environment variables."
-name = "django-getenv"
-optional = false
-python-versions = "*"
-version = "1.3.2"
-
-[[package]]
-category = "main"
 description = "Adds support for using money and currency fields in django models and forms. Uses py-moneyed as the money implementation."
 name = "django-money"
 optional = false
@@ -666,7 +658,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 pgsql = ["psycopg2-binary"]
 
 [metadata]
-content-hash = "5e6867cf2e6874fd70bb74de157ec4bec6895c2dd5ae949c3941517641e01152"
+content-hash = "0da1465985432f2988a3c4b6ce3716bff2eab7fbbe770fc5d0c343532b4905b2"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -722,10 +714,6 @@ django-filter = [
 ]
 django-fullurl = [
     {file = "django_fullurl-1.1-py2.py3-none-any.whl", hash = "sha256:eb05be83671f29544f1ca000b96320b4d17033339b2bec509d88d4e8b285c2ee"},
-]
-django-getenv = [
-    {file = "django-getenv-1.3.2.tar.gz", hash = "sha256:cede44ed68570aefe91a32925b28f1d111c93023bb387c5adb36bbd42c0e5739"},
-    {file = "django_getenv-1.3.2-py2.py3-none-any.whl", hash = "sha256:d292571cefb84904a25d163689fc8f451c3cd090be72c6b3dc60a9c44730baee"},
 ]
 django-money = [
     {file = "django-money-0.15.1.tar.gz", hash = "sha256:88b5a0ee36565a87c39581efedbe4834b6f3f4a9a348887678ed2f45f4f8a192"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ django-favicon = "^0.1.3"
 psycopg2-binary = { version = "^2.8", optional = true }
 django-currentuser = "^0.5"
 uWSGI = "^2.0.0"
-django-getenv = "^1.3.2"
 django-tables2 = "^2.1.1"
 django-crispy-forms = "^1.9.0"
 django-autosequence = "^0"

--- a/schema/migrations/0020_create_superuser.py
+++ b/schema/migrations/0020_create_superuser.py
@@ -2,12 +2,11 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from django.contrib.auth.models import User
 import os
-from getenv import env
 
 
 def forwards_func(apps, schema_editor):
     User.objects.create_superuser('admin', email=env(
-        'CAMERAHUB_ADMIN_EMAIL', 'admin@example.com'), password=env('CAMERAHUB_ADMIN_PASSWORD', 'admin'))
+        'CAMERAHUB_ADMIN_EMAIL', 'admin@example.com'), password=os.getenv('CAMERAHUB_ADMIN_PASSWORD', 'admin'))
 
 
 def reverse_func(apps, schema_editor):

--- a/schema/migrations/0020_create_superuser.py
+++ b/schema/migrations/0020_create_superuser.py
@@ -5,7 +5,7 @@ import os
 
 
 def forwards_func(apps, schema_editor):
-    User.objects.create_superuser('admin', email=env(
+    User.objects.create_superuser('admin', email=os.getenv(
         'CAMERAHUB_ADMIN_EMAIL', 'admin@example.com'), password=os.getenv('CAMERAHUB_ADMIN_PASSWORD', 'admin'))
 
 


### PR DESCRIPTION
Use built-in Python function `getenv()` instead of third-party function `env()`

Fixes #454 