### PR TITLE
Use non-deprecated API for Ingress

### DIFF
--- a/kubernetes/kustomize/camerahub/ingress.yaml
+++ b/kubernetes/kustomize/camerahub/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: camerahub
@@ -9,7 +9,10 @@ spec:
   rules:
     - http:
         paths:
-          - backend:
-              serviceName: camerahub
-              servicePort: 8000
-            path: /
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: camerahub
+                port:
+                  number: 8000

--- a/kubernetes/overlays/preprod/preprod.yaml
+++ b/kubernetes/overlays/preprod/preprod.yaml
@@ -1,6 +1,6 @@
 ---
 # TLS/SSL certs
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: camerahub
@@ -12,9 +12,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: camerahub
-              servicePort: 8000
+              service:
+                name: camerahub
+                port:
+                  number: 8000
   tls:
     - hosts:
         - testing.camerahub.info

--- a/kubernetes/overlays/prod/prod.yaml
+++ b/kubernetes/overlays/prod/prod.yaml
@@ -1,6 +1,6 @@
 ---
 # TLS/SSL certs
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: camerahub
@@ -12,9 +12,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: camerahub
-              servicePort: 8000
+              service:
+                name: camerahub
+                port:
+                  number: 8000
   tls:
     - hosts:
         - camerahub.info


### PR DESCRIPTION
This needs testing in kubernetes before merging

Fixes #544 