### PR TITLE
Revert "Update build-push-action"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Publish to PyPI
         run: poetry publish -n --build --username __token__ --password ${{ secrets.pypi_password }}
       - name: Publish to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1
         with:
           username: djjudas21
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           poetry install
           poetry build
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v1
         with:
           repository: djjudas21/camerahub
           tags: testing


### PR DESCRIPTION
Docker build-push-action doesn't support the tagging behaviour we need in v2 - https://github.com/docker/build-push-action#complete-workflow

This PR switches back to v1 which still works, but is deprecated, so we can reconsider our options

Reverts djjudas21/camerahub#549