### PR TITLE
Improve Scan FK validation

### DIFF
--- a/schema/models.py
+++ b/schema/models.py
@@ -2046,7 +2046,7 @@ class Scan(models.Model):
 
     def clean(self):
         # Check print source
-        if self.negative is not None and self.print is not None:
+        if (self.negative is not None and self.print is not None) or (self.negative is None and self.print is None):
             raise ValidationError({
                 'negative': ValidationError(('Choose either negative or print')),
                 'print': ValidationError(('Choose either negative or print')),


### PR DESCRIPTION
Improve Scan FK validation. It used to complain only if the user specified both film and print, but now also complains if they specify neither.

Fixes #625