### PR TITLE
Add health checks

### DIFF
--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -25,10 +25,10 @@ SECRET_KEY = os.getenv('CAMERAHUB_SECRET_KEY', 'OverrideMe!')
 # SECURITY WARNING: don't run with debug turned on in production!
 if os.getenv('CAMERAHUB_PROD') == 'true':
     DEBUG = False
-    ALLOWED_HOSTS = [os.getenv('CAMERAHUB_DOMAIN', 'camerahub.info')]
 else:
     DEBUG = True
-    ALLOWED_HOSTS = []
+
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 

--- a/kubernetes/kustomize/camerahub/deployment.yaml
+++ b/kubernetes/kustomize/camerahub/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       containers:
         - image: djjudas21/camerahub:0.24.0
           name: camerahub
+          ports:
+          - name: app-port
+            containerPort: 8000
           env:
             # Secrets first
             - name: CAMERAHUB_DB_PASS

--- a/kubernetes/kustomize/camerahub/deployment.yaml
+++ b/kubernetes/kustomize/camerahub/deployment.yaml
@@ -109,6 +109,23 @@ spec:
             - name: media
               mountPath: /camerahub/media
               readOnly: false
+          livenessProbe:
+            tcpSocket:
+              port: app-port
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: app-port
+            periodSeconds: 5
+            timeoutSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /
+              port: app-port
+            failureThreshold: 36
+            periodSeconds: 5
       dnsPolicy: ClusterFirst
       volumes:
       - name: media


### PR DESCRIPTION
* Add health checks to the Kubernetes Deployment, to prevent a condition where the Pod starts up but spends ages doing migrations, but the Service sends traffic to it anyway, giving HTTP error 502.
* Disable Django filtering on `ALLOWED_HOSTS` to permit health probes to succeed. This is potentially a security risk, but should be OK as Django is behind an Ingress that is already doing exactly this.

Fixes #623 