### PR TITLE
Revert "Add curl to docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR $PROJECT_DIR
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 # Install runtime deps
-RUN runDeps='libpq5 libgdal20 libmagic1 mime-support postgresql-client curl' \
+RUN runDeps='libpq5 libgdal20 libmagic1 mime-support postgresql-client' \
   && apt-get update && apt-get install -y $runDeps --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
No longer need `curl` in the Docker image

This reverts commit d3b11bf81118abadfa161c6a195964acbe4c477f.