### PR TITLE
Use tags slugs

### DIFF
--- a/schema/templates/schema/cameramodel_detail.html
+++ b/schema/templates/schema/cameramodel_detail.html
@@ -506,7 +506,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/developer_detail.html
+++ b/schema/templates/schema/developer_detail.html
@@ -49,7 +49,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/enlargermodel_detail.html
+++ b/schema/templates/schema/enlargermodel_detail.html
@@ -78,7 +78,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/filmstock_detail.html
+++ b/schema/templates/schema/filmstock_detail.html
@@ -61,7 +61,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/flashmodel_detail.html
+++ b/schema/templates/schema/flashmodel_detail.html
@@ -165,7 +165,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/lensmodel_detail.html
+++ b/schema/templates/schema/lensmodel_detail.html
@@ -280,7 +280,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/manufacturer_detail.html
+++ b/schema/templates/schema/manufacturer_detail.html
@@ -54,7 +54,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/mount_detail.html
+++ b/schema/templates/schema/mount_detail.html
@@ -50,7 +50,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/paperstock_detail.html
+++ b/schema/templates/schema/paperstock_detail.html
@@ -49,7 +49,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/teleconvertermodel_detail.html
+++ b/schema/templates/schema/teleconvertermodel_detail.html
@@ -88,7 +88,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/schema/toner_detail.html
+++ b/schema/templates/schema/toner_detail.html
@@ -38,7 +38,7 @@
   <tr>
     <td>Tags</td>
     <td>{% for tag in object.tags.all %}
-      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+      <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
       {% endfor %}</td>
   </tr>
   {% endif %}

--- a/schema/templates/tag-detail.html
+++ b/schema/templates/tag-detail.html
@@ -7,8 +7,8 @@
     <p>Public objects can be tagged</p>{%endblock%}
 
 {% block content %}
-<h5>Objects tagged <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' object|lower %}"
-        role="button">{{ object }}</a></h5>
+<h5>Objects tagged <a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' object.slug %}"
+        role="button">{{ object.slug }}</a></h5>
 
 
 <ul>

--- a/schema/templates/tag-list.html
+++ b/schema/templates/tag-list.html
@@ -10,7 +10,7 @@
 {% if object_list %}
 <h5>All tags</h5>
 {% for tag in object_list %}
-<a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag|lower %}" role="button">{{ tag }}</a>
+<a class="btn btn-outline-primary" href="{% url 'schema:tag-detail' tag.slug %}" role="button">{{ tag.slug }}</a>
 {% endfor %}
 {% else %}
 <p>No tags defined yet</p>


### PR DESCRIPTION
Use tag slugs when building URLs. Before we were just downcasing the name which works in most cases but causes problems for tags that have spaces, which get converted to hyphens, etc.

Fixes #747 