### PR TITLE
Also publish CameraHub images to Harbor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,11 @@ jobs:
           repository: camerahub/camerahub
           tag_with_ref: true
           tags: latest
+      - name: Publish to Harbor
+        uses: docker/build-push-action@v1
+        with:
+          username: robot$camerahub
+          password: ${{ secrets.HARBOR_PASSWORD }}
+          repository: registry.apps.gazeley.uk/camerahub/camerahub
+          tag_with_ref: true
+          tags: latest


### PR DESCRIPTION
Also publish CameraHub images to the Harbor instance https://registry.apps.gazeley.uk/harbor/projects/2/repositories/camerahub so we can benefit from vulnerability scanning