### PR TITLE
Explicitly set the type of autofield

### DIFF
--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -300,4 +300,4 @@ SETTINGS_EXPORT = [
 
 # Explicitly set the type of autofield to its current value
 # In Django 3.2+ this will default to BigAutoField
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -300,4 +300,4 @@ SETTINGS_EXPORT = [
 
 # Explicitly set the type of autofield to its current value
 # In Django 3.2+ this will default to BigAutoField
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField

--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -297,3 +297,7 @@ STATUS_URL = os.getenv('CAMERAHUB_STATUS_URL')
 SETTINGS_EXPORT = [
     'STATUS_URL',
 ]
+
+# Explicitly set the type of autofield to its current value
+# In Django 3.2+ this will default to BigAutoField
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
Explicitly set the type of autofield to its current value. In Django 3.2+ this will default to `BigAutoField` and this may cause accidental migrations.

Fixes #833 