### PR TITLE
Express print size in inches

### DIFF
--- a/schema/models.py
+++ b/schema/models.py
@@ -2517,7 +2517,7 @@ class Print(models.Model):
     @property
     def size(self):
         if self.width and self.height:
-            mystr = f"{self.width}×{self.height}mm"
+            mystr = f"{self.width}×{self.height}\""
         else:
             mystr = None
         return mystr


### PR DESCRIPTION
Print size should be expressed in inches, instead of mm

Fixes #896 