### PR TITLE
Display object totals by each index card

### DIFF
--- a/schema/templates/index.html
+++ b/schema/templates/index.html
@@ -40,7 +40,7 @@
                     alt="Camera models"></a>
             <div class="card-body">
                 <a href="{% url 'schema:cameramodel-list' %}">
-                    <h5 class="card-title">Camera models</h5>
+                    <h5 class="card-title">Camera models <span class="badge badge-pill badge-primary">{{ cameramodels }}</span></h5>
                 </a>
             </div>
         </div>
@@ -49,7 +49,7 @@
                     src="{% static "svg/teleconverter.svg" %}" alt="Lens models"></a>
             <div class="card-body">
                 <a href="{% url 'schema:lensmodel-list' %}">
-                    <h5 class="card-title">Lens models</h5>
+                    <h5 class="card-title">Lens models <span class="badge badge-pill badge-primary">{{ lensmodels }}</span></h5>
                 </a>
             </div>
         </div>
@@ -58,7 +58,7 @@
                     alt="Film stocks"></a>
             <div class="card-body">
                 <a href="{% url 'schema:filmstock-list' %}">
-                    <h5 class="card-title">Film stocks</h5>
+                    <h5 class="card-title">Film stocks <span class="badge badge-pill badge-primary">{{ filmstocks }}</span></h5>
                 </a>
             </div>
         </div>

--- a/schema/urls.py
+++ b/schema/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic import TemplateView
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -9,7 +8,7 @@ app_name = 'schema'
 urlpatterns = [
 
     # Static pages
-    path('', TemplateView.as_view(template_name='index.html'), name='index'),
+    path('', views.IndexView.as_view(), name='index'),
     path('stats', views.StatsView.as_view(), name='stats'),
     path('mystats', views.MyStatsView.as_view(), name='mystats'),
     path('search/', views.SearchView.as_view(), name='search'),

--- a/schema/views.py
+++ b/schema/views.py
@@ -1154,6 +1154,16 @@ class TonerUpdate(LoginRequiredMixin, UpdateView):
     template_name = 'update.html'
 
 
+class IndexView(TemplateView):
+    template_name = "index.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['cameramodels'] = CameraModel.objects.count()
+        context['lensmodels'] = LensModel.objects.count()
+        context['filmstocks'] = FilmStock.objects.count()
+        return context
+
 class StatsView(TemplateView):
     template_name = "stats.html"
 


### PR DESCRIPTION
Display object totals by each index card on the index page

The original issue called for counts in the nav menu, but this is a little more difficult because the nav is called from various contexts, and running all those queries would be pretty slow.

So instead I've implemented three object counters in pill form on the index page to show how many camera models, lens models and film stocks there are. Hopefully it'll make the UI a bit more appealing.

Part of #757 