### PR TITLE
Drop storage check because it doesn't work with CephFS. Fixes #922

### DIFF
--- a/camerahub/settings.py
+++ b/camerahub/settings.py
@@ -62,7 +62,6 @@ INSTALLED_APPS = [
     'dbbackup',
     'health_check',
     'health_check.db',
-    'health_check.storage',
     'colorfield',
 ]
 


### PR DESCRIPTION
Drop storage check because it doesn't work with CephFS - see https://github.com/revsys/django-health-check/issues/376

Fixes #922 (or at least works around it)